### PR TITLE
[SIG-55948] Plugin Actions Support: Added custom hook for action registration and triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ function setVariableCallback(value: WorkbookSelection[]): void;
 
 #### useActionTrigger()
 
-Returns a callback function for the registered action trigger to trigger the action(s).
+Returns a callback function to trigger one or more action effects for a given action trigger
 
 ```ts
 function useActionTrigger(triggerId: string);
@@ -702,6 +702,8 @@ function useActionTrigger(triggerId: string);
 Arguments
 
 - `triggerId : string` - The ID of the action trigger
+
+The function that can be called to trigger the action
 
 ```ts
 function triggerActionCallback(): void;

--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ type CustomPluginConfigOptions =
       type: 'interaction';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-trigger';
+      name: string;
+      label?: string;
     };
 ```
 
@@ -376,6 +381,10 @@ Additional Fields
 
 A configurable workbook interaction to interact with other charts within your workbook
 
+**Action Trigger**
+
+A configurable action trigger to trigger actions in other elements within your workbook
+
 #### PluginInstance
 
 ```ts
@@ -436,6 +445,11 @@ interface PluginInstance<T> {
       elementId: string,
       selection: WorkbookSelection[],
     ): void;
+
+    /**
+     * Triggers an action based on the provided action trigger Id
+     */
+    triggerAction(id: string): void;
 
     /**
      * Overrider function for Config Ready state
@@ -675,6 +689,22 @@ The returned setter function accepts an array of workbook selection elements
 
 ```ts
 function setVariableCallback(value: WorkbookSelection[]): void;
+```
+
+#### useActionTrigger()
+
+Returns a callback function for the registered action trigger to trigger the action(s).
+
+```ts
+function useActionTrigger(triggerId: string);
+```
+
+Arguments
+
+- `triggerId : string` - The ID of the action trigger
+
+```ts
+function triggerActionCallback(): void;
 ```
 
 #### useConfig()

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -137,7 +137,9 @@ export function initialize<T = {}>(): PluginInstance<T> {
         void execPromise('wb:plugin:selection:set', id, elementId, selection);
       },
       triggerAction(id: string) {
-        if (!registeredActionTriggers.has(id)) return;
+        if (!registeredActionTriggers.has(id)) {
+          throw new Error(`Invalid action trigger ID: ${id}`);
+        }
         void execPromise('wb:plugin:action-trigger:invoke', id);
       },
       configureEditorPanel(options) {

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -136,10 +136,8 @@ export function initialize<T = {}>(): PluginInstance<T> {
       ) {
         void execPromise('wb:plugin:selection:set', id, elementId, selection);
       },
-      hasTriggerId(id: string) {
-        return registeredActionTriggers.has(id);
-      },
       triggerAction(id: string) {
+        if (!registeredActionTriggers.has(id)) return;
         void execPromise('wb:plugin:action-trigger:invoke', id);
       },
       configureEditorPanel(options) {

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,7 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
-  let actionTriggerIds: Set<string>;
+  let actionTriggerIds: Set<string> = new Set();
 
   const listeners: {
     [event: string]: Function[];
@@ -146,7 +146,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
         return actionTriggerIds.has(id);
       },
       triggerAction(id: string) {
-        execPromise('wb:plugin:action-trigger:invoke', id);
+        void execPromise('wb:plugin:action-trigger:invoke', id);
       },
       configureEditorPanel(options) {
         void execPromise('wb:plugin:config:inspector', options);

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,7 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
-  let actionTriggerIds: Set<string> = new Set();
+  let registeredTriggerIds: Set<string> = new Set();
 
   const listeners: {
     [event: string]: Function[];
@@ -58,6 +58,10 @@ export function initialize<T = {}>(): PluginInstance<T> {
   on('wb:plugin:selection:update', (updatedInteractions: unknown) => {
     subscribedInteractions = {};
     Object.assign(subscribedInteractions, updatedInteractions);
+  });
+
+  on('wb:plugin:action-trigger:update', (updatedTriggerIds: Set<string>) => {
+    registeredTriggerIds = new Set(updatedTriggerIds);
   });
 
   function on(event: string, listener: Function) {
@@ -136,14 +140,14 @@ export function initialize<T = {}>(): PluginInstance<T> {
       ) {
         void execPromise('wb:plugin:selection:set', id, elementId, selection);
       },
-      registerActionTrigger(id: string) {
-        actionTriggerIds.add(id);
-      },
-      unregisterActionTrigger(id: string) {
-        actionTriggerIds.delete(id);
-      },
       hasActionTrigger(id: string): boolean {
-        return actionTriggerIds.has(id);
+        return registeredTriggerIds.has(id);
+      },
+      registerTrigger(id: string) {
+        void execPromise('wb:plugin:action-trigger:register', id);
+      },
+      unregisterTrigger(id: string) {
+        void execPromise('wb:plugin:action-trigger:unregister', id);
       },
       triggerAction(id: string) {
         void execPromise('wb:plugin:action-trigger:invoke', id);

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,6 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
+  let actionTriggers: Record<string, Function> = {};
 
   const listeners: {
     [event: string]: Function[];
@@ -141,6 +142,24 @@ export function initialize<T = {}>(): PluginInstance<T> {
       setLoadingState(loadingState) {
         void execPromise('wb:plugin:config:loading-state', loadingState);
       },
+      registerActionTrigger(id: string, callback: Function) {
+        actionTriggers[id] = callback;
+      },
+      triggerAction(id: string) {
+        const trigger = actionTriggers[id];
+        // might not even need this function, cuz just send a message
+        if (trigger) {
+          trigger();
+        }
+        execPromise('wb:plugin:trigger:set', id);
+      },
+      // getActionTrigger(id: string): Function {
+      //   return actionTriggers[id];
+      // },
+      // setActionTrigger(id: string, triggerFunction: Function): void {
+      //   actionTriggers[id] = triggerFunction;
+      //   void execPromise('wb:plugin:actiontrigger:set', id, triggerFunction);
+      // },
       subscribeToWorkbookVariable(
         id: string,
         callback: (input: WorkbookVariable) => void,

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,7 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
-  let actionTriggers: Record<string, Function> = {};
+  let actionTriggerIds: Set<string>;
 
   const listeners: {
     [event: string]: Function[];
@@ -136,30 +136,24 @@ export function initialize<T = {}>(): PluginInstance<T> {
       ) {
         void execPromise('wb:plugin:selection:set', id, elementId, selection);
       },
+      registerActionTrigger(id: string) {
+        actionTriggerIds.add(id);
+      },
+      unregisterActionTrigger(id: string) {
+        actionTriggerIds.delete(id);
+      },
+      hasActionTrigger(id: string): boolean {
+        return actionTriggerIds.has(id);
+      },
+      triggerAction(id: string) {
+        execPromise('wb:plugin:action-trigger:invoke', id);
+      },
       configureEditorPanel(options) {
         void execPromise('wb:plugin:config:inspector', options);
       },
       setLoadingState(loadingState) {
         void execPromise('wb:plugin:config:loading-state', loadingState);
       },
-      registerActionTrigger(id: string, callback: Function) {
-        actionTriggers[id] = callback;
-      },
-      triggerAction(id: string) {
-        const trigger = actionTriggers[id];
-        // might not even need this function, cuz just send a message
-        if (trigger) {
-          trigger();
-        }
-        execPromise('wb:plugin:trigger:set', id);
-      },
-      // getActionTrigger(id: string): Function {
-      //   return actionTriggers[id];
-      // },
-      // setActionTrigger(id: string, triggerFunction: Function): void {
-      //   actionTriggers[id] = triggerFunction;
-      //   void execPromise('wb:plugin:actiontrigger:set', id, triggerFunction);
-      // },
       subscribeToWorkbookVariable(
         id: string,
         callback: (input: WorkbookVariable) => void,

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -176,3 +176,19 @@ export function useInteraction(
 
   return [workbookInteraction, setInteraction];
 }
+
+/**
+ * React hook for registering a action trigger and returning a triggering function
+ * @param {string} id ID of action trigger
+ * @returns {Function} Function to trigger the registered action
+ */
+
+export function useActionTrigger(id: string): Function {
+  const client = usePlugin();
+
+  client.config.registerActionTrigger(id, () => {});
+
+  return useCallback(() => {
+    client.config.triggerAction(id);
+  }, [client, id]);
+}

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -186,9 +186,15 @@ export function useInteraction(
 export function useActionTrigger(id: string): Function {
   const client = usePlugin();
 
-  client.config.registerActionTrigger(id, () => {});
+  useEffect(() => {
+    client.config.registerActionTrigger(id);
+    return () => {
+      client.config.unregisterActionTrigger(id);
+    };
+  }, [client, id]);
 
   return useCallback(() => {
+    if (!client.config.hasActionTrigger) return;
     client.config.triggerAction(id);
   }, [client, id]);
 }

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -185,13 +185,6 @@ export function useInteraction(
 export function useActionTrigger(id: string) {
   const client = usePlugin();
 
-  useEffect(() => {
-    client.config.registerActionTrigger(id);
-    return () => {
-      client.config.unregisterActionTrigger(id);
-    };
-  }, [client, id]);
-
   return useCallback(() => {
     if (!client.config.hasActionTrigger(id)) return;
     client.config.triggerAction(id);

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -178,15 +178,15 @@ export function useInteraction(
 }
 
 /**
- * React hook for registering a action trigger and returning a triggering callback function
+ * React hook for returning a triggering callback function for the registered
+ * action trigger
  * @param {string} id ID of action trigger
- * @returns {Function} A callback function to trigger the registered action
+ * @returns {Function} A callback function to trigger the action
  */
 export function useActionTrigger(id: string) {
   const client = usePlugin();
 
   return useCallback(() => {
-    if (!client.config.hasActionTrigger(id)) return;
     client.config.triggerAction(id);
   }, [client, id]);
 }

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -182,7 +182,7 @@ export function useInteraction(
  * @param {string} id ID of action trigger
  * @returns {Function} A callback function to trigger the registered action
  */
-export function useActionTrigger(id: string): Function {
+export function useActionTrigger(id: string) {
   const client = usePlugin();
 
   useEffect(() => {
@@ -193,7 +193,7 @@ export function useActionTrigger(id: string): Function {
   }, [client, id]);
 
   return useCallback(() => {
-    if (!client.config.hasActionTrigger) return;
+    if (!client.config.hasActionTrigger(id)) return;
     client.config.triggerAction(id);
   }, [client, id]);
 }

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -178,11 +178,10 @@ export function useInteraction(
 }
 
 /**
- * React hook for registering a action trigger and returning a triggering function
+ * React hook for registering a action trigger and returning a triggering callback function
  * @param {string} id ID of action trigger
- * @returns {Function} Function to trigger the registered action
+ * @returns {Function} A callback function to trigger the registered action
  */
-
 export function useActionTrigger(id: string): Function {
   const client = usePlugin();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,11 @@ export type CustomPluginConfigOptions =
       type: 'interaction';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-trigger';
+      name: string;
+      label?: string;
     };
 
 /**
@@ -254,6 +259,16 @@ export interface PluginInstance<T = any> {
       elementId: string,
       selection: WorkbookSelection[],
     ): void;
+
+    /**
+     * Getter for action trigger state
+     * @param id ID from action-trigger type in Plugin Config
+     */
+    // getActionTrigger(id: string): Function;
+
+    triggerAction(id: string): void;
+
+    registerActionTrigger(id: string, callback: Function): void;
 
     /**
      * Overrider function for Config Ready state

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,22 +261,22 @@ export interface PluginInstance<T = any> {
     ): void;
 
     /**
-     * Registers an action trigger with the given Id
-     * @param {string} id ID from action-trigger type in Plugin Config
-     */
-    registerActionTrigger(id: string): void;
-
-    /**
-     * Unregisters an action trigger with the given Id
-     * @param {string} id ID from action-trigger type in Plugin Config
-     */
-    unregisterActionTrigger(id: string): void;
-
-    /**
      * Checks if action trigger exists
      * @param {string} id ID from action-trigger type in Plugin Config
      */
     hasActionTrigger(id: string): boolean;
+
+    /**
+     * Registers action trigger
+     * @param {string} id ID from action-trigger type in Plugin Config
+     */
+    registerActionTrigger(id: string): boolean;
+
+    /**
+     * Unregisters action trigger
+     * @param {string} id ID from action-trigger type in Plugin Config
+     */
+    unregisterActionTrigger(id: string): boolean;
 
     /**
      * Triggers an action based on the provided action trigger Id

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,18 +267,6 @@ export interface PluginInstance<T = any> {
     hasActionTrigger(id: string): boolean;
 
     /**
-     * Registers action trigger
-     * @param {string} id ID from action-trigger type in Plugin Config
-     */
-    registerActionTrigger(id: string): boolean;
-
-    /**
-     * Unregisters action trigger
-     * @param {string} id ID from action-trigger type in Plugin Config
-     */
-    unregisterActionTrigger(id: string): boolean;
-
-    /**
      * Triggers an action based on the provided action trigger Id
      * @param {string} id ID from action-trigger type in Plugin Config
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,12 +261,6 @@ export interface PluginInstance<T = any> {
     ): void;
 
     /**
-     * Checks if action trigger exists
-     * @param {string} id ID from action-trigger type in Plugin Config
-     */
-    hasActionTrigger(id: string): boolean;
-
-    /**
      * Triggers an action based on the provided action trigger Id
      * @param {string} id ID from action-trigger type in Plugin Config
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,14 +261,28 @@ export interface PluginInstance<T = any> {
     ): void;
 
     /**
-     * Getter for action trigger state
-     * @param id ID from action-trigger type in Plugin Config
+     * Registers an action trigger with the given Id
+     * @param {string} id ID from action-trigger type in Plugin Config
      */
-    // getActionTrigger(id: string): Function;
+    registerActionTrigger(id: string): void;
 
+    /**
+     * Unregisters an action trigger with the given Id
+     * @param {string} id ID from action-trigger type in Plugin Config
+     */
+    unregisterActionTrigger(id: string): void;
+
+    /**
+     * Checks if action trigger exists
+     * @param {string} id ID from action-trigger type in Plugin Config
+     */
+    hasActionTrigger(id: string): boolean;
+
+    /**
+     * Triggers an action based on the provided action trigger Id
+     * @param {string} id ID from action-trigger type in Plugin Config
+     */
     triggerAction(id: string): void;
-
-    registerActionTrigger(id: string, callback: Function): void;
 
     /**
      * Overrider function for Config Ready state


### PR DESCRIPTION
## What is the purpose of this PR?
Added a new `CustomPluginConfigOptions` type. 
Created `useActionTrigger` hook to register/unregister and trigger an action event.

Next step will be to register triggers on Slate.