### PR TITLE
Plugin action-effect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ type CustomPluginConfigOptions =
       type: 'action-trigger';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-effect';
+      name: string;
+      label?: string;
     };
 ```
 
@@ -447,9 +452,19 @@ interface PluginInstance<T> {
     ): void;
 
     /**
-     * Triggers an action based on the provided action trigger Id
+     * Triggers an action based on the provided action trigger ID
      */
     triggerAction(id: string): void;
+
+    /**
+     * Registers an effect with the provided action effect ID
+     */
+    registerEffect(id: string, effect: Function): void;
+
+    /**
+     * Unregisters an effect based on the provided action effect ID
+     */
+    unregisterEffect(id: string): void;
 
     /**
      * Overrider function for Config Ready state
@@ -708,6 +723,19 @@ The function that can be called to trigger the action
 ```ts
 function triggerActionCallback(): void;
 ```
+
+#### useActionEffect()
+
+Registers and unregisters an action effect within the plugin
+
+```ts
+function useActionEffect(effectId: string, effect: Function);
+```
+
+Arguments
+
+- `effectId : string` - The ID of the action effect
+- `effect : Function` - The function to be called when the effect is triggered
 
 #### useConfig()
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,5 @@
     "ttypescript": "^1.5.13",
     "typescript": "^4.8.2",
     "typescript-transform-paths": "^3.3.1"
-  },
-  "packageManager": "yarn@4.3.1+sha512.af78262d7d125afbfeed740602ace8c5e4405cd7f4735c08feb327286b2fdb2390fbca01589bfd1f50b1240548b74806767f5a063c94b67e431aabd0d86f7774"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "ttypescript": "^1.5.13",
     "typescript": "^4.8.2",
     "typescript-transform-paths": "^3.3.1"
-  }
+  },
+  "packageManager": "yarn@4.3.1+sha512.af78262d7d125afbfeed740602ace8c5e4405cd7f4735c08feb327286b2fdb2390fbca01589bfd1f50b1240548b74806767f5a063c94b67e431aabd0d86f7774"
 }

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -63,7 +63,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
   on('wb:plugin:action-effect:invoke', (id: string) => {
     const effect = registeredEffects[id];
     if (!effect) {
-      console.warn('No effect found.');
+      throw new Error('No effect found.');
     }
     effect();
   });

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -62,10 +62,8 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   on('wb:plugin:action-effect:invoke', (id: string) => {
     const effect = registeredEffects[id];
-    if (!effect) {
-      console.warn('No effect found.');
-    }
-    effect();
+    if (effect) effect();
+    else console.warn('No effect found.');
   });
 
   function on(event: string, listener: Function) {

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -63,7 +63,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
   on('wb:plugin:action-effect:invoke', (id: string) => {
     const effect = registeredEffects[id];
     if (!effect) {
-      throw new Error('No effect found.');
+      console.warn('No effect found.');
     }
     effect();
   });

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,6 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
+  let registeredEffects: Record<string, Function> = {};
 
   const listeners: {
     [event: string]: Function[];
@@ -57,6 +58,14 @@ export function initialize<T = {}>(): PluginInstance<T> {
   on('wb:plugin:selection:update', (updatedInteractions: unknown) => {
     subscribedInteractions = {};
     Object.assign(subscribedInteractions, updatedInteractions);
+  });
+
+  on('wb:plugin:action-effect:invoke', (id: string) => {
+    const effect = registeredEffects[id];
+    if (!effect) {
+      throw new Error('No effect found.');
+    }
+    effect();
   });
 
   function on(event: string, listener: Function) {
@@ -137,6 +146,12 @@ export function initialize<T = {}>(): PluginInstance<T> {
       },
       triggerAction(id: string) {
         void execPromise('wb:plugin:action-trigger:invoke', id);
+      },
+      registerEffect(id: string, effect: Function) {
+        registeredEffects[id] = effect;
+      },
+      unregisterEffect(id: string) {
+        delete registeredEffects[id];
       },
       configureEditorPanel(options) {
         void execPromise('wb:plugin:config:inspector', options);

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -190,3 +190,20 @@ export function useActionTrigger(id: string) {
     client.config.triggerAction(id);
   }, [client, id]);
 }
+
+/**
+ * React hook for registering and unregistering an action effect
+ * @param {string} id ID of action effect
+ * @param {Function} effect The function to be called when the action is triggered
+ */
+export function useActionEffect(id: string, effect: Function) {
+  const client = usePlugin();
+
+  useEffect(() => {
+    client.config.registerEffect(id, effect);
+    console.log('effectId', id);
+    return () => {
+      client.config.unregisterEffect(id);
+    };
+  }, [client, id]);
+}

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -201,7 +201,6 @@ export function useActionEffect(id: string, effect: Function) {
 
   useEffect(() => {
     client.config.registerEffect(id, effect);
-    console.log('effectId', id);
     return () => {
       client.config.unregisterEffect(id);
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,10 +266,23 @@ export interface PluginInstance<T = any> {
     ): void;
 
     /**
-     * Triggers an action based on the provided action trigger Id
+     * Triggers an action based on the provided action trigger ID
      * @param {string} id ID from action-trigger type in Plugin Config
      */
     triggerAction(id: string): void;
+
+    /**
+     * Registers an effect with the provided action effect ID
+     * @param {string} id ID from action-effect type in Plugin Config
+     * @param effect The effect function to register
+     */
+    registerEffect(id: string, effect: Function): void;
+
+    /**
+     * Unregisters an effect based on the provided action effect ID
+     * @param {string} id ID from action-effect type in Plugin Config
+     */
+    unregisterEffect(id: string): void;
 
     /**
      * Overrider function for Config Ready state

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,11 @@ export type CustomPluginConfigOptions =
       type: 'action-trigger';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-effect';
+      name: string;
+      label?: string;
     };
 
 /**


### PR DESCRIPTION
- Added a new `action-effect` type.
- Created `useActionEffect` hook to register an action effect with the provided effect ID.
- Added a listener that calls the effect upon receiving `wb:plugin:action-effect:invoke` from Slate.
- Updated README.

Corresponding PR on Slate: https://github.com/sigmacomputing/slate/pull/35490

How it will look like in custom plugin:
```
useEditorPanelConfig([{ type: 'action-effect', name: 'exampleEffect' }]);

useActionEffect(config.exampleEffect, triggerEffect);

function triggerEffect() {
 //...
}
```
