### PR TITLE
[Plugin Action Support] Add missing dependency for action effect hook 

### DIFF
--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -204,5 +204,5 @@ export function useActionEffect(id: string, effect: Function) {
     return () => {
       client.config.unregisterEffect(id);
     };
-  }, [client, id]);
+  }, [client, id, effect]);
 }


### PR DESCRIPTION
Found this bug that makes the Cypress test flaky. Adding `effect` in the dependency array ensures the effect is correctly registered when the effect function changes and properly cleaned up when the component unmounts or dependencies change.