### PR TITLE
Add support Actions within plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Before you start:
 #### CustomPluginConfigOptions
 
 A plugin can be configured with any number of configuration fields. Each field
-type has its own configuration options. Each field type is also garunteed to
-have a the following options:
+type has its own configuration options. Each field type is also guaranteed to
+have the following options:
 
 - `name : string` - the name of the field
 - `type : string` - the field type
@@ -689,7 +689,7 @@ function setVariableCallback(...values: unknown[]): void;
 
 #### useInteraction()
 
-Returns a given interaction's selection state and a setter to update that interation
+Returns a given interaction's selection state and a setter to update that interaction
 
 ```ts
 function useInteraction(

--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ type CustomPluginConfigOptions =
       type: 'action-trigger';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-effect';
+      name: string;
+      label?: string;
     };
 ```
 
@@ -447,9 +452,19 @@ interface PluginInstance<T> {
     ): void;
 
     /**
-     * Triggers an action based on the provided action trigger Id
+     * Triggers an action based on the provided action trigger ID
      */
     triggerAction(id: string): void;
+
+    /**
+     * Registers an effect with the provided action effect ID
+     */
+    registerEffect(id: string, effect: Function): void;
+
+    /**
+     * Unregisters an effect based on the provided action effect ID
+     */
+    unregisterEffect(id: string): void;
 
     /**
      * Overrider function for Config Ready state
@@ -708,6 +723,19 @@ The function that can be called to trigger the action
 ```ts
 function triggerActionCallback(): void;
 ```
+
+#### useActionEffect()
+
+Registers and unregisters an action effect within the plugin
+
+```ts
+function useActionEffect(effectId: string, effect: Function);
+```
+
+Arguments
+
+- `effectId : string` - The ID of the action effect
+- `effect : Function` - The function to be called when the effect is triggered
 
 #### useConfig()
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,10 @@ A configurable workbook interaction to interact with other charts within your wo
 
 A configurable action trigger to trigger actions in other elements within your workbook
 
+**Action Effect**
+
+A configurable action effect that can be triggered by other elements within your workbook
+
 #### PluginInstance
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ type CustomPluginConfigOptions =
       type: 'interaction';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-trigger';
+      name: string;
+      label?: string;
     };
 ```
 
@@ -376,6 +381,10 @@ Additional Fields
 
 A configurable workbook interaction to interact with other charts within your workbook
 
+**Action Trigger**
+
+A configurable action trigger to trigger actions in other elements within your workbook
+
 #### PluginInstance
 
 ```ts
@@ -436,6 +445,11 @@ interface PluginInstance<T> {
       elementId: string,
       selection: WorkbookSelection[],
     ): void;
+
+    /**
+     * Triggers an action based on the provided action trigger Id
+     */
+    triggerAction(id: string): void;
 
     /**
      * Overrider function for Config Ready state
@@ -675,6 +689,24 @@ The returned setter function accepts an array of workbook selection elements
 
 ```ts
 function setVariableCallback(value: WorkbookSelection[]): void;
+```
+
+#### useActionTrigger()
+
+Returns a callback function to trigger one or more action effects for a given action trigger
+
+```ts
+function useActionTrigger(triggerId: string);
+```
+
+Arguments
+
+- `triggerId : string` - The ID of the action trigger
+
+The function that can be called to trigger the action
+
+```ts
+function triggerActionCallback(): void;
 ```
 
 #### useConfig()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/plugin",
-  "version": "1.0.5",
+  "version": "1.0.8-beta",
   "description": "Sigma Computing Plugin Client API",
   "license": "MIT",
   "homepage": "https://github.com/sigmacomputing/plugin",

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,6 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
+  const registeredActionTriggers = new Set<string>();
 
   const listeners: {
     [event: string]: Function[];
@@ -135,7 +136,18 @@ export function initialize<T = {}>(): PluginInstance<T> {
       ) {
         void execPromise('wb:plugin:selection:set', id, elementId, selection);
       },
+      triggerAction(id: string) {
+        if (!registeredActionTriggers.has(id)) {
+          throw new Error(`Invalid action trigger ID: ${id}`);
+        }
+        void execPromise('wb:plugin:action-trigger:invoke', id);
+      },
       configureEditorPanel(options) {
+        registeredActionTriggers.clear();
+        for (const option of options) {
+          if (option.type !== 'action-trigger') continue;
+          registeredActionTriggers.add(option.name);
+        }
         void execPromise('wb:plugin:config:inspector', options);
       },
       setLoadingState(loadingState) {

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,6 +14,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
+  let registeredEffects: Record<string, Function> = {};
 
   const listeners: {
     [event: string]: Function[];
@@ -57,6 +58,12 @@ export function initialize<T = {}>(): PluginInstance<T> {
   on('wb:plugin:selection:update', (updatedInteractions: unknown) => {
     subscribedInteractions = {};
     Object.assign(subscribedInteractions, updatedInteractions);
+  });
+
+  on('wb:plugin:action-effect:invoke', (id: string) => {
+    const effect = registeredEffects[id];
+    if (effect) effect();
+    else console.warn('No effect found.');
   });
 
   function on(event: string, listener: Function) {
@@ -137,6 +144,12 @@ export function initialize<T = {}>(): PluginInstance<T> {
       },
       triggerAction(id: string) {
         void execPromise('wb:plugin:action-trigger:invoke', id);
+      },
+      registerEffect(id: string, effect: Function) {
+        registeredEffects[id] = effect;
+      },
+      unregisterEffect(id: string) {
+        delete registeredEffects[id];
       },
       configureEditorPanel(options) {
         void execPromise('wb:plugin:config:inspector', options);

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -14,7 +14,6 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
   let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
-  const registeredActionTriggers = new Set<string>();
 
   const listeners: {
     [event: string]: Function[];
@@ -137,17 +136,9 @@ export function initialize<T = {}>(): PluginInstance<T> {
         void execPromise('wb:plugin:selection:set', id, elementId, selection);
       },
       triggerAction(id: string) {
-        if (!registeredActionTriggers.has(id)) {
-          throw new Error(`Invalid action trigger ID: ${id}`);
-        }
         void execPromise('wb:plugin:action-trigger:invoke', id);
       },
       configureEditorPanel(options) {
-        registeredActionTriggers.clear();
-        for (const option of options) {
-          if (option.type !== 'action-trigger') continue;
-          registeredActionTriggers.add(option.name);
-        }
         void execPromise('wb:plugin:config:inspector', options);
       },
       setLoadingState(loadingState) {

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -204,5 +204,5 @@ export function useActionEffect(id: string, effect: Function) {
     return () => {
       client.config.unregisterEffect(id);
     };
-  }, [client, id]);
+  }, [client, id, effect]);
 }

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -190,3 +190,19 @@ export function useActionTrigger(id: string) {
     client.config.triggerAction(id);
   }, [client, id]);
 }
+
+/**
+ * React hook for registering and unregistering an action effect
+ * @param {string} id ID of action effect
+ * @param {Function} effect The function to be called when the action is triggered
+ */
+export function useActionEffect(id: string, effect: Function) {
+  const client = usePlugin();
+
+  useEffect(() => {
+    client.config.registerEffect(id, effect);
+    return () => {
+      client.config.unregisterEffect(id);
+    };
+  }, [client, id]);
+}

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -176,3 +176,17 @@ export function useInteraction(
 
   return [workbookInteraction, setInteraction];
 }
+
+/**
+ * React hook for returning a triggering callback function for the registered
+ * action trigger
+ * @param {string} id ID of action trigger
+ * @returns {Function} A callback function to trigger the action
+ */
+export function useActionTrigger(id: string) {
+  const client = usePlugin();
+
+  return useCallback(() => {
+    client.config.triggerAction(id);
+  }, [client, id]);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,11 @@ export type CustomPluginConfigOptions =
       type: 'interaction';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-trigger';
+      name: string;
+      label?: string;
     };
 
 /**
@@ -254,6 +259,12 @@ export interface PluginInstance<T = any> {
       elementId: string,
       selection: WorkbookSelection[],
     ): void;
+
+    /**
+     * Triggers an action based on the provided action trigger Id
+     * @param {string} id ID from action-trigger type in Plugin Config
+     */
+    triggerAction(id: string): void;
 
     /**
      * Overrider function for Config Ready state

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,11 @@ export type CustomPluginConfigOptions =
       type: 'action-trigger';
       name: string;
       label?: string;
+    }
+  | {
+      type: 'action-effect';
+      name: string;
+      label?: string;
     };
 
 /**
@@ -261,10 +266,23 @@ export interface PluginInstance<T = any> {
     ): void;
 
     /**
-     * Triggers an action based on the provided action trigger Id
+     * Triggers an action based on the provided action trigger ID
      * @param {string} id ID from action-trigger type in Plugin Config
      */
     triggerAction(id: string): void;
+
+    /**
+     * Registers an effect with the provided action effect ID
+     * @param {string} id ID from action-effect type in Plugin Config
+     * @param effect The effect function to register
+     */
+    registerEffect(id: string, effect: Function): void;
+
+    /**
+     * Unregisters an effect based on the provided action effect ID
+     * @param {string} id ID from action-effect type in Plugin Config
+     */
+    unregisterEffect(id: string): void;
 
     /**
      * Overrider function for Config Ready state


### PR DESCRIPTION
** This PR requires a bit of cleanup before it is ready to be merged **

This PR adds support for plugins to trigger actions in workbooks and for workbook actions to call functions within a plugin using the notions of `action trigger` (plugin -> workbook) and `action effect` (workbook -> plugin).

This PR adds the following config options:
* `action-trigger`: This corresponds to an Action selectable within workbook UI by selecting a Plugin, navigating to the Actions sidebar, and adding an Action.
* `action-effect`: This corresponds to a new Action type within workbooks. This is selectable by selecting any Action in a workbook, and selecting `Trigger plugin`, then selected the configured `action-effect`

It adds the following functions:
* `triggerAction`: This function, when called with the config object, will trigger all Actions configured in the workbook UI under the current plugin element
* `registerEffect`: This function registers a handler for when a certain Action, as configured in UI, is triggered.
* `unregisterEffect`: This function will remove any registration (done with the function just above) associated with the id passed in

In addition, it adds the following react hooks:
* `useActionTrigger`: This function returns a callback that triggers the action associated with the id passed in
* `useActionEffect`: This function takes in the associated config item, and handles the unsubscribe on unmount