### PR TITLE
Deprecate Interaction API, to be replaced by Actions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,6 @@ type CustomPluginConfigOptions =
       name: string;
       label?: string;
       allowedTypes?: ControlType[];
-    }
-  | {
-      type: 'interaction';
-      name: string;
-      label?: string;
     };
 ```
 
@@ -424,20 +419,6 @@ interface PluginInstance<T> {
     setVariable(id: string, ...values: unknown[]): void;
 
     /**
-     * Getter for interaction selection state
-     */
-    getInteraction(id: string): WorkbookSelection[];
-
-    /**
-     * Setter for interaction selection state
-     */
-    setInteraction(
-      id: string,
-      elementId: string,
-      selection: WorkbookSelection[],
-    ): void;
-
-    /**
      * Overrider function for Config Ready state
      */
     setLoadingState(ready: boolean): void;
@@ -448,14 +429,6 @@ interface PluginInstance<T> {
     subscribeToWorkbookVariable(
       id: string,
       callback: (input: WorkbookVariable) => void,
-    ): Unsubscriber;
-
-    /**
-     * Allows users to subscribe to changes in the passed in interaction ID
-     */
-    subscribeToWorkbookInteraction(
-      id: string,
-      callback: (input: WorkbookSelection[]) => void,
     ): Unsubscriber;
   };
 
@@ -652,29 +625,6 @@ array or multiple parameters
 
 ```ts
 function setVariableCallback(...values: unknown[]): void;
-```
-
-#### useInteraction()
-
-Returns a given interaction's selection state and a setter to update that interation
-
-```ts
-function useInteraction(
-  interactionId: string,
-  elementId: string,
-): [WorkbookSelection | undefined, (value: WorkbookSelection[]) => void];
-```
-
-Arguments
-
-- `interactionId : string` - The ID of the interaction
-- `elementId : string` - The ID of the element that this interaction is
-  associated with
-
-The returned setter function accepts an array of workbook selection elements
-
-```ts
-function setVariableCallback(value: WorkbookSelection[]): void;
 ```
 
 #### useConfig()

--- a/README.md
+++ b/README.md
@@ -477,6 +477,15 @@ interface PluginInstance<T> {
       id: string,
       callback: (input: WorkbookVariable) => void,
     ): Unsubscriber;
+
+    /**
+     * @deprecated Use Action API instead
+     * Allows users to subscribe to changes in the passed in interaction ID
+     */
+    subscribeToWorkbookInteraction(
+      id: string,
+      callback: (input: WorkbookSelection[]) => void,
+    ): Unsubscriber;
   };
 
   elements: {

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -12,7 +12,6 @@ export function initialize<T = {}>(): PluginInstance<T> {
     config: {} as T,
   };
 
-  let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
 
   const listeners: {
@@ -53,11 +52,6 @@ export function initialize<T = {}>(): PluginInstance<T> {
       Object.assign(subscribedWorkbookVars, updatedVariables);
     },
   );
-
-  on('wb:plugin:selection:update', (updatedInteractions: unknown) => {
-    subscribedInteractions = {};
-    Object.assign(subscribedInteractions, updatedInteractions);
-  });
 
   function on(event: string, listener: Function) {
     listeners[event] = listeners[event] || [];
@@ -123,18 +117,6 @@ export function initialize<T = {}>(): PluginInstance<T> {
       setVariable(id: string, ...values: unknown[]) {
         void execPromise('wb:plugin:variable:set', id, ...values);
       },
-      getInteraction(id: string) {
-        return subscribedInteractions[id];
-      },
-      setInteraction(
-        id: string,
-        elementId: string,
-        selection:
-          | string[]
-          | Array<Record<string, { type: string; val?: unknown }>>,
-      ) {
-        void execPromise('wb:plugin:selection:set', id, elementId, selection);
-      },
       configureEditorPanel(options) {
         void execPromise('wb:plugin:config:inspector', options);
       },
@@ -151,18 +133,6 @@ export function initialize<T = {}>(): PluginInstance<T> {
         on('wb:plugin:variable:update', setValues);
         return () => {
           off('wb:plugin:variable:update', setValues);
-        };
-      },
-      subscribeToWorkbookInteraction(
-        id: string,
-        callback: (input: WorkbookSelection[]) => void,
-      ): Unsubscriber {
-        const setValues = (values: Record<string, WorkbookSelection[]>) => {
-          callback(values[id]);
-        };
-        on('wb:plugin:selection:update', setValues);
-        return () => {
-          off('wb:plugin:selection:update', setValues);
         };
       },
     },

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -12,6 +12,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
     config: {} as T,
   };
 
+  let subscribedInteractions: Record<string, WorkbookSelection[]> = {};
   let subscribedWorkbookVars: Record<string, WorkbookVariable> = {};
   const registeredEffects: Record<string, () => void> = {};
 
@@ -170,6 +171,18 @@ export function initialize<T = {}>(): PluginInstance<T> {
           off('wb:plugin:variable:update', setValues);
         };
       },
+      subscribeToWorkbookInteraction(
+        id: string,
+        callback: (input: WorkbookSelection[]) => void,
+      ): Unsubscriber {
+        const setValues = (values: Record<string, WorkbookSelection[]>) => {
+          callback(values[id]);
+        };
+        on('wb:plugin:selection:update', setValues);
+        return () => {
+          off('wb:plugin:selection:update', setValues);
+        };
+      },
     },
     elements: {
       getElementColumns(id) {
@@ -197,7 +210,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
       },
       fetchMoreElementData(id) {
         void execPromise('wb:plugin:element:fetch-more', id);
-      }
+      },
     },
     destroy() {
       Object.keys(listeners).forEach(event => delete listeners[event]);

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -146,33 +146,3 @@ export function useVariable(
 
   return [workbookVariable, setVariable];
 }
-
-/**
- * React hook for accessing a workbook interaction selections state
- * @param {string} id ID of variable within Plugin Config to use
- * @returns {[(WorkbookSelection | undefined), Function]} Constantly updating selection state and setter thereof
- */
-export function useInteraction(
-  id: string,
-  elementId: string,
-): [unknown, Function] {
-  const client = usePlugin();
-  const [workbookInteraction, setWorkbookInteraction] =
-    useState<WorkbookSelection[]>();
-
-  useEffect(() => {
-    return client.config.subscribeToWorkbookInteraction(
-      id,
-      setWorkbookInteraction,
-    );
-  }, [client, id]);
-
-  const setInteraction = useCallback(
-    (value: WorkbookSelection[]) => {
-      client.config.setInteraction(id, elementId, value);
-    },
-    [id],
-  );
-
-  return [workbookInteraction, setInteraction];
-}

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -180,7 +180,9 @@ export function useVariable(
 
   return [workbookVariable, setVariable];
 }
+
 /**
+ * @deprecated Use Action API instead
  * React hook for accessing a workbook interaction selections state
  * @param {string} id ID of variable within Plugin Config to use
  * @returns {[(WorkbookSelection | undefined), Function]} Constantly updating selection state and setter thereof

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,12 +248,14 @@ export interface PluginInstance<T = any> {
     setVariable(id: string, ...values: unknown[]): void;
 
     /**
+     * @deprecated Use Action API instead
      * Getter for interaction selection state
      * @param {string} id ID from interaction type in Plugin Config
      */
     getInteraction(id: string): WorkbookSelection[];
 
     /**
+     * @deprecated Use Action API instead
      * Setter for interaction selection state
      * @param {string} id ID from interaction type in Plugin Config
      * @param {string} elementId Source element ID from element type in Plugin Config
@@ -294,6 +296,18 @@ export interface PluginInstance<T = any> {
     subscribeToWorkbookVariable(
       id: string,
       callback: (input: WorkbookVariable) => void,
+    ): Unsubscriber;
+
+    /**
+     * @deprecated Use Action API instead
+     * Allows users to subscribe to changes in the passed in interaction ID
+     * @param {string} id ID of the interaction variable within Plugin Config
+     * @callback callback Function to be called upon receiving an updated interaction selection state
+     * @returns {Unsubscriber} A callable unsubscriber
+     */
+    subscribeToWorkbookInteraction(
+      id: string,
+      callback: (input: WorkbookSelection[]) => void,
     ): Unsubscriber;
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,11 +161,6 @@ export type CustomPluginConfigOptions =
       name: string;
       label?: string;
       allowedTypes?: ControlType[];
-    }
-  | {
-      type: 'interaction';
-      name: string;
-      label?: string;
     };
 
 /**
@@ -238,24 +233,6 @@ export interface PluginInstance<T = any> {
     setVariable(id: string, ...values: unknown[]): void;
 
     /**
-     * Getter for interaction selection state
-     * @param {string} id ID from interaction type in Plugin Config
-     */
-    getInteraction(id: string): WorkbookSelection[];
-
-    /**
-     * Setter for interaction selection state
-     * @param {string} id ID from interaction type in Plugin Config
-     * @param {string} elementId Source element ID from element type in Plugin Config
-     * @param {Object} selection List of column IDs or Columns and values and key-value pairs to select
-     */
-    setInteraction(
-      id: string,
-      elementId: string,
-      selection: WorkbookSelection[],
-    ): void;
-
-    /**
      * Overrider function for Config Ready state
      * @param {boolean} loadingState Boolean representing if Plugin Config is still loading
      */
@@ -270,17 +247,6 @@ export interface PluginInstance<T = any> {
     subscribeToWorkbookVariable(
       id: string,
       callback: (input: WorkbookVariable) => void,
-    ): Unsubscriber;
-
-    /**
-     * Allows users to subscribe to changes in the passed in interaction ID
-     * @param {string} id ID of the interaction variable within Plugin Config
-     * @callback callback Function to be called upon receiving an updated interaction selection state
-     * @returns {Unsubscriber} A callable unsubscriber
-     */
-    subscribeToWorkbookInteraction(
-      id: string,
-      callback: (input: WorkbookSelection[]) => void,
     ): Unsubscriber;
   };
 


### PR DESCRIPTION
This PR removes the Interaction API, since we're intending on replacing this feature with the new Actions API in the next minor version release.