### PR TITLE
[Control API] Initialize state correctly in `useVariable`

### DIFF
--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -163,7 +163,9 @@ export function useVariable(
   id: string,
 ): [WorkbookVariable | undefined, Function] {
   const client = usePlugin();
-  const [workbookVariable, setWorkbookVariable] = useState<WorkbookVariable>();
+  const [workbookVariable, setWorkbookVariable] = useState<WorkbookVariable>(
+    client.config.getVariable(id),
+  );
 
   useEffect(() => {
     return client.config.subscribeToWorkbookVariable(id, setWorkbookVariable);


### PR DESCRIPTION
We previously were initializing this to `undefined` which would most of the time be reasonable, but we cache the plugin's variable state, so if we subscribe and fetch the variable before this hook is called, we would never receive the message from sigma and update the value. This fixes the hook to grab any variable we already received from sigma for that id in state.