### PR TITLE
[useVariable] More consistent fix for initialization logic

### DIFF
--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -163,11 +163,15 @@ export function useVariable(
   id: string,
 ): [WorkbookVariable | undefined, Function] {
   const client = usePlugin();
-  const [workbookVariable, setWorkbookVariable] = useState<WorkbookVariable>(
-    client.config.getVariable(id),
-  );
+  const [workbookVariable, setWorkbookVariable] = useState<WorkbookVariable>();
+
+  const isFirstRender = useRef<boolean>(true);
 
   useEffect(() => {
+    if (isFirstRender.current) {
+      setWorkbookVariable(client.config.getVariable(id));
+      isFirstRender.current = false;
+    }
     return client.config.subscribeToWorkbookVariable(id, setWorkbookVariable);
   }, [client, id]);
 


### PR DESCRIPTION
This ensures that there's no gap between our initialization from `useState` (during render time) and `useEffect` (post render) for our variable update to come in, which would be missed by this. The alternative to this is to subscribe during render time, but this makes cleanup unnecessarily tricky.