### PR TITLE
[Plugin] Listens to workbook theme color changes

### DIFF
--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -115,7 +115,7 @@ export function initialize<T = {}>(): PluginInstance<T> {
       return pluginConfig.themeColors;
     },
 
-    subscribeToThemeColors(callback: (themeColors: PluginThemeColors) => void) {
+    onThemeChange(callback: (themeColors: PluginThemeColors) => void) {
       on('wb:plugin:theme:update', callback);
       return () => off('wb:plugin:theme:update', callback);
     },

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -3,6 +3,7 @@ import {
   PluginConfig,
   PluginInstance,
   PluginMessageResponse,
+  PluginThemeColors,
   WorkbookSelection,
   WorkbookVariable,
 } from '../types';
@@ -68,6 +69,10 @@ export function initialize<T = {}>(): PluginInstance<T> {
     effect();
   });
 
+  on('wb:plugin:theme:update', (themeColors: PluginThemeColors) => {
+    pluginConfig.themeColors = themeColors;
+  });
+
   function on(event: string, listener: Function) {
     listeners[event] = listeners[event] || [];
     listeners[event].push(listener);
@@ -104,6 +109,15 @@ export function initialize<T = {}>(): PluginInstance<T> {
 
     get isScreenshot() {
       return pluginConfig.screenshot;
+    },
+
+    get themeColors() {
+      return pluginConfig.themeColors;
+    },
+
+    subscribeToThemeColors(callback: (themeColors: PluginThemeColors) => void) {
+      on('wb:plugin:theme:update', callback);
+      return () => off('wb:plugin:theme:update', callback);
     },
 
     config: {

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -257,8 +257,10 @@ export function useThemeColors(): PluginThemeColors | undefined {
   const [themeColors, setThemeColors] = useState(client.themeColors);
 
   useEffect(() => {
+    // Initial sync
     setThemeColors(client.themeColors);
-    return client.subscribeToThemeColors(setThemeColors);
+
+    return client.onThemeChange(setThemeColors);
   }, [client]);
 
   return themeColors;

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -8,6 +8,7 @@ import {
   WorkbookElementData,
   WorkbookSelection,
   WorkbookVariable,
+  PluginThemeColors,
 } from '../types';
 import { deepEqual } from '../utils/deepEqual';
 
@@ -245,4 +246,20 @@ export function useActionEffect(configId: string, effect: () => void) {
   useEffect(() => {
     return client.config.registerEffect(configId, effectRef.current);
   }, [client, configId, effect]);
+}
+
+/**
+ * React hook for accessing workbook theme colors with live updates
+ * @returns {PluginThemeColors | undefined} Theme colors from the workbook if available
+ */
+export function useThemeColors(): PluginThemeColors | undefined {
+  const client = usePlugin();
+  const [themeColors, setThemeColors] = useState(client.themeColors);
+
+  useEffect(() => {
+    setThemeColors(client.themeColors);
+    return client.subscribeToThemeColors(setThemeColors);
+  }, [client]);
+
+  return themeColors;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,19 @@ export interface PluginConfig<T> {
   id: string;
   config: T;
   screenshot: boolean;
+  themeColors?: PluginThemeColors;
   [key: string]: any;
+}
+
+/**
+ * Theme colors available to plugins
+ * @typedef {object} PluginThemeColors
+ * @property {string} backgroundColor Background color from workbook theme
+ * @property {string} textColor Primary text color from workbook theme
+ */
+export interface PluginThemeColors {
+  backgroundColor: string;
+  textColor: string;
 }
 
 /**
@@ -188,6 +200,21 @@ export type CustomPluginConfigOptions =
  */
 export interface PluginInstance<T = any> {
   sigmaEnv: 'author' | 'viewer' | 'explorer';
+
+  /**
+   * Theme colors from the workbook
+   * @returns {PluginThemeColors | undefined} Theme colors if available
+   */
+  themeColors?: PluginThemeColors | undefined;
+
+  /**
+   * Subscribe to theme color changes
+   * @param {Function} callback Function to call when theme colors change
+   * @returns {Function} Unsubscriber function
+   */
+  subscribeToThemeColors(
+    callback: (themeColors: PluginThemeColors) => void,
+  ): () => void;
 
   config: {
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,13 +208,11 @@ export interface PluginInstance<T = any> {
   themeColors?: PluginThemeColors | undefined;
 
   /**
-   * Subscribe to theme color changes
+   * Listen to theme color changes
    * @param {Function} callback Function to call when theme colors change
    * @returns {Function} Unsubscriber function
    */
-  subscribeToThemeColors(
-    callback: (themeColors: PluginThemeColors) => void,
-  ): () => void;
+  onThemeChange(callback: (themeColors: PluginThemeColors) => void): () => void;
 
   config: {
     /**


### PR DESCRIPTION


- Adds `useThemeColors()` hook for automatic theme color updates
- Adds `themeColors` property on plugin instance, right now it has two fields: `backgroundColor` and `textColor`. We can expand in the future.
- Will update readme when this is finalized.

Sample plugin app:
```
function App() {
  const themeColors = useThemeColors();

  return (
    <div
      style={{ backgroundColor: themeColors?.backgroundColor }}
    >
      <p style={{ color: themeColors?.textColor }}>
        ...
      </p>
    </div>
  );
}
```