### PR TITLE
Deprecate @sigmacomputing/plugin in favor of @sigmacomputing/plugin-sdk

### DIFF
--- a/packages/plugin-sdk/tsdown.config.ts
+++ b/packages/plugin-sdk/tsdown.config.ts
@@ -1,15 +1,2 @@
-import { defineConfig, mergeConfig } from 'tsdown';
-
 // @ts-ignore - base config is defined outside of this package
-import baseConfig from '../../tsdown.base.ts';
-
-import packageJson from './package.json' with { type: 'json' };
-
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    define: {
-      __VERSION__: JSON.stringify(packageJson.version),
-    },
-  }),
-);
+export { default } from '../../tsdown.base.ts';

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -1,15 +1,2 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
-
 // @ts-ignore - base config is defined outside of this package
-import baseConfig from '../../vitest.base.ts';
-
-import packageJson from './package.json' with { type: 'json' };
-
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    define: {
-      __VERSION__: JSON.stringify(packageJson.version),
-    },
-  }),
-);
+export { default } from '../../vitest.base.ts';

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,0 +1,37 @@
+# `@sigmacomputing/plugin` is deprecated
+
+> **This package has been renamed to [`@sigmacomputing/plugin-sdk`](https://www.npmjs.com/package/@sigmacomputing/plugin-sdk).**
+>
+> `@sigmacomputing/plugin` will no longer receive updates. Please migrate your
+> projects to `@sigmacomputing/plugin-sdk` to continue receiving new features
+> and bug fixes.
+
+This package is now a thin compatibility shim that re-exports everything from
+`@sigmacomputing/plugin-sdk`. It emits a `console.warn` at import time to
+remind consumers to migrate.
+
+## Migrating
+
+Replace your dependency on `@sigmacomputing/plugin` with `@sigmacomputing/plugin-sdk`:
+
+```sh
+yarn remove @sigmacomputing/plugin
+yarn add @sigmacomputing/plugin-sdk
+```
+
+```sh
+npm uninstall @sigmacomputing/plugin
+npm install @sigmacomputing/plugin-sdk
+```
+
+Then update your imports:
+
+```diff
+-import { client, initialize } from '@sigmacomputing/plugin';
++import { client, initialize } from '@sigmacomputing/plugin-sdk';
+```
+
+The public API is unchanged — only the package name is different.
+
+For documentation, examples, and the changelog, see the
+[`@sigmacomputing/plugin-sdk`](https://github.com/sigmacomputing/plugin) repository.

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -13,7 +13,7 @@
     "types": "yarn g:types"
   },
   "dependencies": {
-    "@sigmacomputing/plugin-sdk": "workspace:^"
+    "@sigmacomputing/plugin-sdk": "^1.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -29,6 +29,8 @@
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.cts",
+  "unpkg": "./dist/umd/sigmacomputing-plugin.umd.js",
+  "jsdelivr": "./dist/umd/sigmacomputing-plugin.umd.js",
   "exports": {
     ".": {
       "import": {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@sigmacomputing/plugin-sdk",
+  "name": "@sigmacomputing/plugin",
   "version": "1.2.0",
-  "description": "Sigma Computing Plugin Client SDK",
+  "description": "Deprecated: use @sigmacomputing/plugin-sdk instead.",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -10,9 +10,10 @@
     "format": "yarn g:format",
     "lint": "yarn g:lint",
     "publish": "yarn g:publlish",
-    "test": "vitest run",
-    "test:watch": "vitest",
     "types": "yarn g:types"
+  },
+  "dependencies": {
+    "@sigmacomputing/plugin-sdk": "workspace:^"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -23,14 +24,11 @@
     }
   },
   "devDependencies": {
-    "tsdown": "^0.21.10",
-    "vitest": "^4.1.5"
+    "tsdown": "^0.21.10"
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.cts",
-  "unpkg": "./dist/umd/sigmacomputing-plugin.umd.js",
-  "jsdelivr": "./dist/umd/sigmacomputing-plugin.umd.js",
   "exports": {
     ".": {
       "import": {
@@ -46,8 +44,7 @@
   },
   "files": [
     "dist/**/*",
-    "src/**/*",
-    "!src/**/__tests__/**/*"
+    "src/**/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,0 +1,6 @@
+console.warn(
+  '[@sigmacomputing/plugin] This package is deprecated and will no longer receive updates. ' +
+    'Please migrate to @sigmacomputing/plugin-sdk: https://github.com/sigmacomputing/plugin',
+);
+
+export * from '@sigmacomputing/plugin-sdk';

--- a/packages/plugin/tsconfig.app.json
+++ b/packages/plugin/tsconfig.app.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+
+    "noEmit": true
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/packages/plugin/tsconfig.node.json
+++ b/packages/plugin/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
+  },
+  "include": ["tsdown.config.ts"]
+}

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -1,29 +1,15 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, mergeConfig } from 'tsdown';
 
-export default defineConfig({
-  clean: true,
-  failOnWarn: true,
-  logLevel: 'warn',
+// @ts-ignore - base config is defined outside of this package
+import baseConfig from '../../tsdown.base.ts';
 
-  dts: true,
-  entry: ['./src/index.ts'],
-  format: {
-    esm: {
-      outputOptions: {
-        dir: './dist/esm',
-      },
+import packageJson from './package.json' with { type: 'json' };
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    define: {
+      __VERSION__: JSON.stringify(packageJson.version),
     },
-    cjs: {
-      outputOptions: {
-        dir: './dist/cjs',
-      },
-    },
-  },
-  platform: 'browser',
-  sourcemap: true,
-  tsconfig: './tsconfig.app.json',
-
-  publint: true,
-  attw: true,
-  unused: true,
-});
+  }),
+);

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  clean: true,
+  failOnWarn: true,
+  logLevel: 'warn',
+
+  dts: true,
+  entry: ['./src/index.ts'],
+  format: {
+    esm: {
+      outputOptions: {
+        dir: './dist/esm',
+      },
+    },
+    cjs: {
+      outputOptions: {
+        dir: './dist/cjs',
+      },
+    },
+  },
+  platform: 'browser',
+  sourcemap: true,
+  tsconfig: './tsconfig.app.json',
+
+  publint: true,
+  attw: true,
+  unused: true,
+});

--- a/packages/plugin/tsdown.config.ts
+++ b/packages/plugin/tsdown.config.ts
@@ -1,15 +1,2 @@
-import { defineConfig, mergeConfig } from 'tsdown';
-
 // @ts-ignore - base config is defined outside of this package
-import baseConfig from '../../tsdown.base.ts';
-
-import packageJson from './package.json' with { type: 'json' };
-
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    define: {
-      __VERSION__: JSON.stringify(packageJson.version),
-    },
-  }),
-);
+export { default } from '../../tsdown.base.ts';

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -100,13 +100,27 @@ const readCurrentVersion = (): semver.SemVer => {
   return parsed;
 };
 
+const WORKSPACE_DEP_SCOPE = '@sigmacomputing/';
+
 const writeNewVersion = (pkgPath: string, version: string): void => {
   const raw = readFileSync(pkgPath, 'utf8');
   const pattern = /("version"\s*:\s*")[^"]+(")/;
   if (!pattern.test(raw)) {
     throw new Error(`Failed to locate "version" field in ${pkgPath}`);
   }
-  writeFileSync(pkgPath, raw.replace(pattern, `$1${version}$2`));
+  const withVersion = raw.replace(pattern, `$1${version}$2`);
+
+  const escaped = WORKSPACE_DEP_SCOPE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const depPattern = new RegExp(
+    `("${escaped}[^"]+"\\s*:\\s*")(\\^|~)?[^"]+(")`,
+    'g',
+  );
+  const withDeps = withVersion.replace(
+    depPattern,
+    (_match, prefix, range, suffix) => `${prefix}${range ?? '^'}${version}${suffix}`,
+  );
+
+  writeFileSync(pkgPath, withDeps);
 };
 
 type TurboQueryLsResponse = {

--- a/vitest.base.ts
+++ b/vitest.base.ts
@@ -1,8 +1,11 @@
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
+import packageJson from './package.json' with { type: 'json' };
+
 export default defineConfig({
   define: {
+    __VERSION__: JSON.stringify(packageJson.version),
     __VITEST_BROWSER__: true.toString(),
   },
   oxc: {


### PR DESCRIPTION
## Summary

- Renames the existing package in `packages/plugin-sdk` from `@sigmacomputing/plugin` to `@sigmacomputing/plugin-sdk`.
- Adds a new `packages/plugin` workspace that keeps the `@sigmacomputing/plugin` name as a thin compatibility shim.
- The shim depends on `@sigmacomputing/plugin-sdk` via `workspace:^`, re-exports its full public API (`export * from '@sigmacomputing/plugin-sdk'`), and emits a `console.warn` at import time directing consumers to migrate.
- New `packages/plugin/README.md` clearly marks the package as deprecated and walks through migration.

## Notes

- The shim only emits ESM and CJS bundles (no UMD). UMD was dropped here because the deprecated package would otherwise have to inline all of `@sigmacomputing/plugin-sdk` into a UMD bundle, which is undesirable for a transitional shim. CDN/UMD users should migrate to `@sigmacomputing/plugin-sdk`.
- The `workspace:^` dependency on `@sigmacomputing/plugin-sdk` will be rewritten by yarn at publish time to `^<version>`.
- Existing top-level `README.md` / `CHANGELOG.md` / `CONTRIBUTING.md` references to `@sigmacomputing/plugin` were intentionally left as-is — happy to update those in a follow-up if desired.

## Test plan

- [ ] `yarn install` resolves the new workspace package
- [ ] `yarn build` produces `dist/{esm,cjs}` for both packages
- [ ] `yarn types` passes
- [ ] `yarn test` passes (the shim has no tests; plugin-sdk tests run unchanged)
- [ ] Import `@sigmacomputing/plugin` in a sample project and confirm the deprecation `console.warn` fires and all named exports still resolve


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1SP9fUC2qHtjsi3zSUBuH)_