### PR TITLE
Cleanup shared configs

### DIFF
--- a/packages/plugin-sdk/tsconfig.app.json
+++ b/packages/plugin-sdk/tsconfig.app.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.app.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+
+    "jsx": "react",
   },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/packages/plugin-sdk/tsdown.config.ts
+++ b/packages/plugin-sdk/tsdown.config.ts
@@ -3,14 +3,9 @@ import { defineConfig, mergeConfig } from 'tsdown';
 // @ts-ignore - base config is defined outside of this package
 import baseConfig from '../../tsdown.base.ts';
 
-import packageJson from './package.json' with { type: 'json' };
-
 export default mergeConfig(
   baseConfig,
   defineConfig({
-    define: {
-      __VERSION__: JSON.stringify(packageJson.version),
-    },
     format: {
       umd: {
         deps: {

--- a/packages/plugin-sdk/tsdown.config.ts
+++ b/packages/plugin-sdk/tsdown.config.ts
@@ -3,9 +3,15 @@ import { defineConfig, mergeConfig } from 'tsdown';
 // @ts-ignore - base config is defined outside of this package
 import baseConfig from '../../tsdown.base.ts';
 
+import packageJson from './package.json' with { type: 'json' };
+
 export default mergeConfig(
   baseConfig,
   defineConfig({
+    define: {
+      __VERSION__: JSON.stringify(packageJson.version),
+    },
+
     format: {
       umd: {
         deps: {
@@ -16,6 +22,19 @@ export default mergeConfig(
           // or TS will throw a type error.
           skipNodeModulesBundle: false,
         },
+        outputOptions: {
+          entryFileNames: 'sigmacomputing-plugin.umd.js',
+          globals: {
+            react: 'React',
+          },
+          name: 'SigmaPlugin',
+        },
+      },
+    },
+
+    inputOptions: {
+      transform: {
+        jsx: 'react',
       },
     },
   }),

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -1,4 +1,18 @@
+import { mergeConfig } from 'vitest/config';
+
 // @ts-ignore - base config is defined outside of this package
 import baseConfig from '../../vitest.base.ts';
 
-export default baseConfig;
+import packageJson from './package.json' with { type: 'json' };
+
+export default mergeConfig(baseConfig, {
+  define: {
+    __VERSION__: JSON.stringify(packageJson.version),
+  },
+  optimizeDeps: {
+    include: ['react/jsx-dev-runtime'],
+  },
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+});

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -1,15 +1,4 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
-
 // @ts-ignore - base config is defined outside of this package
 import baseConfig from '../../vitest.base.ts';
 
-import packageJson from './package.json' with { type: 'json' };
-
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    define: {
-      __VERSION__: JSON.stringify(packageJson.version),
-    },
-  }),
-);
+export default baseConfig;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,6 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
     "lib": ["DOM", "ESNext"],
-    "jsx": "react",
-    "types": ["vitest/globals"]
-  }
+    "types": ["vitest/globals"],
+  },
 }

--- a/tsdown.base.ts
+++ b/tsdown.base.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'tsdown';
 
-import packageJson from './package.json' with { type: 'json' };
-
 export default defineConfig({
   clean: true,
   failOnWarn: true,
@@ -23,18 +21,8 @@ export default defineConfig({
     umd: {
       outputOptions: {
         dir: './dist/umd',
-        entryFileNames: 'sigmacomputing-plugin.umd.js',
-        globals: {
-          react: 'React',
-        },
         minify: true,
-        name: 'SigmaPlugin',
       },
-    },
-  },
-  inputOptions: {
-    transform: {
-      jsx: 'react',
     },
   },
   platform: 'browser',
@@ -42,7 +30,6 @@ export default defineConfig({
   tsconfig: './tsconfig.app.json',
 
   define: {
-    __VERSION__: JSON.stringify(packageJson.version),
     __VITEST_BROWSER__: false.toString(),
   },
 

--- a/vitest.base.ts
+++ b/vitest.base.ts
@@ -1,8 +1,11 @@
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
+import packageJson from './package.json' with { type: 'json' };
+
 export default defineConfig({
   define: {
+    __VERSION__: JSON.stringify(packageJson.version),
     __VITEST_BROWSER__: true.toString(),
   },
   oxc: {

--- a/vitest.base.ts
+++ b/vitest.base.ts
@@ -1,22 +1,13 @@
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
-import packageJson from './package.json' with { type: 'json' };
-
 export default defineConfig({
   define: {
-    __VERSION__: JSON.stringify(packageJson.version),
     __VITEST_BROWSER__: true.toString(),
-  },
-  oxc: {
-    jsx: { runtime: 'automatic' },
-  },
-  optimizeDeps: {
-    include: ['react/jsx-dev-runtime'],
   },
   test: {
     globals: true,
-    include: ['src/**/*.test.{js,jsx,ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}'],
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
## Summary
Reverses direction from the original "move `__VERSION__` into root base configs" — instead, all `@sigmacomputing/plugin`-specific settings are pulled *out* of the shared root configs and pushed *into* `packages/plugin-sdk/`. The root base configs now hold only settings that genuinely apply to every workspace package.

**Moved out of root base configs into `packages/plugin-sdk/`:**
- `tsdown.base.ts` → `packages/plugin-sdk/tsdown.config.ts`: `__VERSION__` define, `inputOptions.transform.jsx: 'react'`, and the UMD `outputOptions` (`entryFileNames`, `globals.react`, `name`).
- `vitest.base.ts` → `packages/plugin-sdk/vitest.config.ts`: `__VERSION__` define, `oxc.jsx`, and the `react/jsx-dev-runtime` `optimizeDeps` entry.
- `tsconfig.app.json` → `packages/plugin-sdk/tsconfig.app.json`: `"jsx": "react"`.

**Other tightening in the root bases:**
- `vitest.base.ts` test include narrowed from `src/**/*.test.{js,jsx,ts,tsx}` to `src/**/*.test.{ts,tsx}` (no JS/JSX test files in workspace packages).

## Test plan
- [ ] `yarn turbo build` succeeds and the UMD/ESM/CJS bundles still embed the correct version at `__VERSION__` (consumed in `packages/plugin-sdk/src/client/initialize.ts:54`) and produce `sigmacomputing-plugin.umd.js` with the `SigmaPlugin` global.
- [ ] `yarn turbo test` passes — `__VERSION__`, JSX transform, and `react/jsx-dev-runtime` resolution still work from the package-local vitest config.
- [ ] `yarn turbo types` / `tsc -b` passes — `jsx: "react"` is correctly picked up from the package's `tsconfig.app.json`.